### PR TITLE
Explicitly specify memory and timeout for layoutcalculator.

### DIFF
--- a/amplify/backend/function/layoutcalculator/layoutcalculator-cloudformation-template.json
+++ b/amplify/backend/function/layoutcalculator/layoutcalculator-cloudformation-template.json
@@ -80,7 +80,8 @@
         },
         "Runtime": "nodejs14.x",
         "Layers": [],
-        "Timeout": 25
+        "MemorySize": 1024,
+        "Timeout": 85
       }
     },
     "LambdaExecutionRole": {


### PR DESCRIPTION
Manually edited the Amplify cloudformation template to properly setup the memory and time restrictions for the layout calculator.