### PR TITLE
Add missing dynamo DB permissions

### DIFF
--- a/amplify/backend/function/batchdatafetcher/batchdatafetcher-cloudformation-template.json
+++ b/amplify/backend/function/batchdatafetcher/batchdatafetcher-cloudformation-template.json
@@ -188,6 +188,38 @@
           ]
         }
       }
+    },
+    "CustomLambdaExecutionPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "custom-lambda-execution-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:Get*",
+                "dynamodb:BatchGetItem",
+                "dynamodb:List*",
+                "dynamodb:Describe*",
+                "dynamodb:Scan",
+                "dynamodb:Query"
+              ],
+              "Resource": [
+                "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev",
+                "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev/index/*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": "LambdaExecutionRole"
     }
   },
   "Outputs": {

--- a/amplify/backend/function/batchdatafetcher/custom-policies.json
+++ b/amplify/backend/function/batchdatafetcher/custom-policies.json
@@ -1,6 +1,17 @@
 [
   {
-    "Action": [],
-    "Resource": []
+    "Action": [
+      "dynamodb:Get*",
+      "dynamodb:BatchGetItem",
+      "dynamodb:List*",
+      "dynamodb:Describe*",
+      "dynamodb:Scan",
+      "dynamodb:Query"
+    ],
+    "Resource": [
+      "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev",
+      "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev/index/*"
+    ],
+    "Effect": "Allow"
   }
 ]

--- a/amplify/backend/function/datafetcher/custom-policies.json
+++ b/amplify/backend/function/datafetcher/custom-policies.json
@@ -1,6 +1,17 @@
 [
   {
-    "Action": [],
-    "Resource": []
+    "Action": [
+      "dynamodb:Get*",
+      "dynamodb:BatchGetItem",
+      "dynamodb:List*",
+      "dynamodb:Describe*",
+      "dynamodb:Scan",
+      "dynamodb:Query"
+    ],
+    "Resource": [
+      "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev",
+      "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev/index/*"
+    ],
+    "Effect": "Allow"
   }
 ]

--- a/amplify/backend/function/datafetcher/datafetcher-cloudformation-template.json
+++ b/amplify/backend/function/datafetcher/datafetcher-cloudformation-template.json
@@ -188,6 +188,38 @@
           ]
         }
       }
+    },
+    "CustomLambdaExecutionPolicy": {
+      "Type": "AWS::IAM::Policy",
+      "Properties": {
+        "PolicyName": "custom-lambda-execution-policy",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "dynamodb:Get*",
+                "dynamodb:BatchGetItem",
+                "dynamodb:List*",
+                "dynamodb:Describe*",
+                "dynamodb:Scan",
+                "dynamodb:Query"
+              ],
+              "Resource": [
+                "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev",
+                "arn:aws:dynamodb:eu-central-1:275192370238:table/Caselaw-avqb7mqbcfgurbeqbfsmuwxjqq-dev/index/*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        },
+        "Roles": [
+          {
+            "Ref": "LambdaExecutionRole"
+          }
+        ]
+      },
+      "DependsOn": "LambdaExecutionRole"
     }
   },
   "Outputs": {


### PR DESCRIPTION
The datafetcher and batchdatafetcher both require DynamoDB permissions that were not listed in the Amplify configuration. This change causes the lambdas to be set up correctly.