### PR TITLE
Download metadata button

### DIFF
--- a/components/CaseLawExplorer/components/ActionBar/Right.tsx
+++ b/components/CaseLawExplorer/components/ActionBar/Right.tsx
@@ -2,40 +2,66 @@ import React from 'react'
 import { 
   View
 } from 'colay-ui'
+import { download } from 'colay-ui/utils'
 import {
   Button
 } from '@mui/material'
 
-type P = {
-  type: string;
-  payload?: any
+import * as API from '../../API'
+import { FullGraphContext, UIStateContext } from '../../Contexts'
+import { Graph, Node } from '../../types'
+
+async function testAPI() {
+    const testResult = await API.testAuth({
+        ecli: "ECLI:NL:HR:2004:AP0186"
+    })
+    console.log('testAuthResult',testResult)
 }
 
-type ActionBarRightProps = {
-  dispatch: (e: P) => void
+async function downloadMetaData
+( fullGraph: Graph
+, updateFullGraph: (fun: (draft: Graph) => void) => void
+) {
+    const nodeChunks: { id: string }[][] = []
+    const chunkSize = 1000;
+    for (let i = 0; i < fullGraph.nodes.length; i += chunkSize) {
+        const slice: Node[] = fullGraph.nodes.slice(i, i + chunkSize)
+        nodeChunks.push(slice.map(({ id }) => ({id})));
+    }
+
+    const nodesWithMetaData = await Promise.all(
+        nodeChunks.map((nodes) => API.batchGetElementData({ nodes: nodes }))
+    ).then((results) => results.flat(1)) // flatten the results of the chunks
+
+    const nodeMap: { [idx: string]: Node } = {}
+    fullGraph.nodes.forEach((node: Node) => { nodeMap[node.id] = node })
+    const result = nodesWithMetaData.map(({ id, data,...rest }) => {
+        return {
+            id,
+            data: {
+                ...(nodeMap[id].data ?? {}),
+                ...data,
+            },
+            ...rest,
+        }
+    })
+
+    updateFullGraph((draft: Graph) => { draft.nodes = result})
+    download(result, 'perfect-graph.json')
 }
 
-export const ActionBarRight = (props: ActionBarRightProps) => {
-  const {
-    dispatch
-  } = props
+export function ActionBarRight() {
+  const { updateState } = React.useContext(UIStateContext)
+  const { fullGraph, updateFullGraph } = React.useContext(FullGraphContext)
   return (
-    <View
-      style={{ flexDirection: 'row' }}
-    >
-      <Button
-        onClick={() => dispatch({ type: 'help'})}
-      >
+    <View style={{ flexDirection: 'row' }}>
+      <Button onClick={() => updateState((draft: any) => draft.helpModal.isOpen = true)} >
         Help
       </Button>
-      <Button
-        onClick={() => dispatch({ type: 'downloadMetaData'})}
-      >
+      <Button onClick={async () => downloadMetaData(fullGraph, updateFullGraph)} >
         Download MetaData
       </Button>
-      <Button
-        onClick={() =>  dispatch({ type: 'testAPI'})}
-      >
+      <Button onClick={testAPI} >
         Test the API
       </Button>
     </View>

--- a/components/CaseLawExplorer/index.tsx
+++ b/components/CaseLawExplorer/index.tsx
@@ -268,61 +268,6 @@ const AppContainer = ({
       isOpen: false,
     }
   })
-  const ActionBarRightWrapped = React.useMemo(() => () => {
-    const [
-      {
-        nodes,
-      },
-    ] = useGraphEditor(
-      ({ nodes }) => ({
-        nodes,
-      }),
-    )
-    return(
-      <ActionBarRight
-        dispatch={async ({ type }) => {
-          switch (type) {
-            case 'help':
-              updateState((draft) => {
-                draft.helpModal.isOpen = true
-              })
-              break;
-            case 'downloadMetaData':{
-              console.log('downloadMetaData')
-              const nodesWithMetaData = await API.batchGetElementData({
-                nodes: nodes.map(({ id }) => ({id})),  // needs to be in the format [{id: String}, {id: String}, ...]
-              })
-              console.log('WithMetaData',nodesWithMetaData)
-              controller.update((draft) =>{
-                const nodeMap = R.indexBy(R.prop('id'), nodesWithMetaData)
-                draft.nodes = nodesWithMetaData.map(({ id, data,...rest }) => {
-                  return {
-                    id,
-                    data: {
-                      ...data,
-                      ...(nodeMap[id].data?? {})
-                    },
-                    ...rest,
-                  }
-                })
-                draft.edges = filterEdges(draft.nodes)(draft.edges)
-              })
-              break;
-            }
-            case 'testAPI':{
-              const testResult = await API.testAuth({
-                ecli: "ECLI:NL:HR:2004:AP0186"
-              })
-              console.log('testAuthResult',testResult)
-              break;
-            }
-
-            default:
-              break;
-          }
-        }}
-      />
-      )}, [dispatch])
 
   /* Stores data of the full unclustered graph */
   const [fullGraph, updateFullGraph] = useImmer({
@@ -434,7 +379,7 @@ const AppContainer = ({
     },
     actionBar: {
       // isOpen: true,
-      right: ActionBarRightWrapped,
+      right: ActionBarRight,
       // autoOpen: true,
       eventRecording: false,
       actions: {

--- a/components/CaseLawExplorer/index.tsx
+++ b/components/CaseLawExplorer/index.tsx
@@ -699,7 +699,6 @@ const AppContainer = ({
       return () => {}
     }
 
-    ClusterCache.reset()
     const {nodes, edges} = clusterGraph(fullGraph)
     controller.update((draft) => {
       draft.isLoading = false
@@ -837,6 +836,7 @@ const AppContainer = ({
           PIXI.settings.SCALE_MODE = PIXI.SCALE_MODES.NEAREST
           PIXI.settings.SPRITE_BATCH_SIZE = 4096 * 4
 
+          ClusterCache.reset()
           updateFullGraph((draft) => {
             draft.nodes = nodes
             draft.edges = edges


### PR DESCRIPTION
Changed the metadata download button to directly download the metadata to a json file, rather than having to go through the download, then using `perfect-graph`'s export option. At some point someone will probably want to dig into perfect-graph and rework how that works, but this should work for now.

This also parallelises the metadata fetching, which reduces the time it takes from >30s to 2-5 seconds.

@shashankmc 